### PR TITLE
♻️ Refactor:  리딩룸 생성하기 페이지 공용 만들기

### DIFF
--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -92,7 +92,7 @@ const router = createBrowserRouter([
           },
           {
             path: 'create',
-            element: <CreateReadingRoom/>,
+            element: <CreateReadingRoom usage='create'/>,
           }
         ],
       },

--- a/src/store/private-reading-room/useModalStore.tsx
+++ b/src/store/private-reading-room/useModalStore.tsx
@@ -3,10 +3,17 @@ import { create } from 'zustand';
 interface ModalStore {
   isExitModalOpen: boolean;
   isDeleteModalOpen: boolean;
+  isEditModalOpen: boolean;
+  openEditModal: () => void;
+  closeEditModal: () => void;
+
   setExitModalOpen: (state: boolean) => void;
   setDeleteModalOpen: (state: boolean) => void;
+  setEditModalOpen: (state: boolean) => void;
+
   toggleExitModal: () => void;
   toggleDeleteModal: () => void;
+  toggleEditModal: () => void; 
 }
 
 const useModalStore = create<ModalStore>((set) => {
@@ -15,12 +22,18 @@ const useModalStore = create<ModalStore>((set) => {
   return {
     isExitModalOpen: initialModalState,
     isDeleteModalOpen: initialModalState,
+    isEditModalOpen: initialModalState,
+    openEditModal: () => set({ isEditModalOpen: true }),
+    closeEditModal: () => set({ isEditModalOpen: false }),  
     setExitModalOpen: (state) => set({ isExitModalOpen: state }),
     setDeleteModalOpen: (state) => set({ isDeleteModalOpen: state }),
+    setEditModalOpen: (state) => set({ isEditModalOpen: state }),
     toggleExitModal: () =>
       set((prev) => ({ isExitModalOpen: !prev.isExitModalOpen })),
     toggleDeleteModal: () =>
       set((prev) => ({ isDeleteModalOpen: !prev.isDeleteModalOpen })),
+    toggleEditModal: () =>
+      set((prev) => ({ isEditModalOpen: !prev.isEditModalOpen })),
   };
 });
 

--- a/src/views/reading-room/components/ActionButtons.tsx
+++ b/src/views/reading-room/components/ActionButtons.tsx
@@ -17,38 +17,40 @@ const ActionButtons = ({
 
     if (usage === 'create') {
         return (
-            <button
-                onClick={() => !disabled && create()}
-                className="flex justify-center items-center w-81 h-20 rounded-lg border mt-110 ml-150"
-                style={{
-                    backgroundColor: disabled ? 'transparent' : 'rgba(122,191,201,1)',
-                    borderColor: disabled ? 'rgba(66, 60, 53,1)' : 'transparent',
-                    pointerEvents: disabled ? 'none' : 'auto',
-                    color: disabled ? 'rgba(66,60,53,1)' : 'black',
-                }}
-            >
-            
-                <div
-                    className="flex justify-center items-center rounded-full border mr-5 p-1"
-                    style={{ borderColor: 'rgba(43, 34, 23, 1)' }}
+            <div className='flex justify-end'>
+                <button
+                    onClick={() => !disabled && create()}
+                    className="flex justify-center items-center w-81 h-20 rounded-lg border mt-70"
+                    style={{
+                        backgroundColor: disabled ? 'transparent' : 'rgba(122,191,201,1)',
+                        borderColor: disabled ? 'rgba(66, 60, 53,1)' : 'transparent',
+                        pointerEvents: disabled ? 'none' : 'auto',
+                        color: disabled ? 'rgba(66,60,53,1)' : 'black',
+                    }}
                 >
-                    <svg xmlns="http://www.w3.org/2000/svg" width="9" height="9" viewBox="0 0 9 8" fill="none">
-                        <path
-                            d="M4.44488 0.185547V4.00083M4.44488 7.8161V4.00083M4.44488 4.00083H0.722656M4.44488 4.00083H8.1671"
-                            stroke="#2B2217"
-                            strokeWidth="0.372222"
-                            strokeLinecap="round"
-                        />
-                    </svg>
-                </div>
-                <div className="text-sm">리딩룸 생성하기</div>
-            </button>
+            
+                    <div
+                        className="flex justify-center items-center rounded-full border mr-5 p-1"
+                        style={{ borderColor: 'rgba(43, 34, 23, 1)' }}
+                    >
+                        <svg xmlns="http://www.w3.org/2000/svg" width="9" height="9" viewBox="0 0 9 8" fill="none">
+                            <path
+                                d="M4.44488 0.185547V4.00083M4.44488 7.8161V4.00083M4.44488 4.00083H0.722656M4.44488 4.00083H8.1671"
+                                stroke="#2B2217"
+                                strokeWidth="0.372222"
+                                strokeLinecap="round"
+                            />
+                        </svg>
+                    </div>
+                    <div className="text-sm">리딩룸 생성하기</div>
+                </button>
+            </div>
         );
     }
 
     if (usage === 'edit') {
         return (
-            <div className="flex flex-row gap-3 mt-6">
+            <div className="flex flex-row justify-end gap-3 mt-6 mt-60">
                 <button
                     onClick={edit}
                     className="flex items-center w-46 h-16 bg-[rgba(122,191,201,1)] text-sm px-10 py-4 rounded-lg"
@@ -59,7 +61,7 @@ const ActionButtons = ({
         
                 <button
                     onClick={cancel}
-                    className="flex items-center w-32 w-16 border text-sm px-10 py-4 rounded-lg"
+                    className="flex justify-center items-center w-32 h-16 border text-sm px-8 py-4 rounded-lg"
                     style={{ 
                         borderColor: 'rgba(255,255,255,0.5)',
                         color: 'rgba(255,255,255,0.5)',

--- a/src/views/reading-room/components/ActionButtons.tsx
+++ b/src/views/reading-room/components/ActionButtons.tsx
@@ -1,0 +1,77 @@
+// components/ActionButtons.tsx
+import React from 'react';
+import { useReadingRoomActions } from '../contexts/ReadingRoomActionsContext';
+
+type ButtonType = 'create' | 'edit';
+
+interface ActionButtonsProps {
+    usage: ButtonType;
+    disabled?: boolean;
+}
+
+const ActionButtons = ({
+    usage,
+    disabled = false,
+}: ActionButtonsProps) => {
+    const { create, edit, cancel } = useReadingRoomActions();;
+
+    if (usage === 'create') {
+        return (
+            <button
+                onClick={() => !disabled && create()}
+                className="flex justify-center items-center w-81 h-20 rounded-lg border mt-110 ml-150"
+                style={{
+                    backgroundColor: disabled ? 'transparent' : 'rgba(122,191,201,1)',
+                    borderColor: disabled ? 'rgba(66, 60, 53,1)' : 'transparent',
+                    pointerEvents: disabled ? 'none' : 'auto',
+                    color: disabled ? 'rgba(66,60,53,1)' : 'black',
+                }}
+            >
+            
+                <div
+                    className="flex justify-center items-center rounded-full border mr-5 p-1"
+                    style={{ borderColor: 'rgba(43, 34, 23, 1)' }}
+                >
+                    <svg xmlns="http://www.w3.org/2000/svg" width="9" height="9" viewBox="0 0 9 8" fill="none">
+                        <path
+                            d="M4.44488 0.185547V4.00083M4.44488 7.8161V4.00083M4.44488 4.00083H0.722656M4.44488 4.00083H8.1671"
+                            stroke="#2B2217"
+                            strokeWidth="0.372222"
+                            strokeLinecap="round"
+                        />
+                    </svg>
+                </div>
+                <div className="text-sm">리딩룸 생성하기</div>
+            </button>
+        );
+    }
+
+    if (usage === 'edit') {
+        return (
+            <div className="flex flex-row gap-3 mt-6">
+                <button
+                    onClick={edit}
+                    className="flex items-center w-46 h-16 bg-[rgba(122,191,201,1)] text-sm px-10 py-4 rounded-lg"
+                    style={{ color: 'rgba(43, 34, 23, 1)'}}
+                >
+                    정보 수정
+                </button>
+        
+                <button
+                    onClick={cancel}
+                    className="flex items-center w-32 w-16 border text-sm px-10 py-4 rounded-lg"
+                    style={{ 
+                        borderColor: 'rgba(255,255,255,0.5)',
+                        color: 'rgba(255,255,255,0.5)',
+                    }}
+                >
+                    취소
+                </button>
+            </div>
+        );
+    }
+
+    return null;
+};
+
+export default ActionButtons;

--- a/src/views/reading-room/components/private-reading-room/common/ModifyModal.tsx
+++ b/src/views/reading-room/components/private-reading-room/common/ModifyModal.tsx
@@ -1,0 +1,14 @@
+// components/common/Modal.tsx
+import { ReactNode } from 'react';
+
+export default function Modal({
+    children
+    }: { children: ReactNode; onClose: () => void }) {
+        return (
+        <div className="fixed inset-0 z-[9999] flex justify-center items-center">
+            <div className="w-462 h-280 backdrop-blur-md rounded-lg">
+                {children}
+            </div>
+        </div>
+    );
+}

--- a/src/views/reading-room/components/private-reading-room/common/ModifyModal.tsx
+++ b/src/views/reading-room/components/private-reading-room/common/ModifyModal.tsx
@@ -6,7 +6,7 @@ export default function Modal({
     }: { children: ReactNode; onClose: () => void }) {
         return (
         <div className="fixed inset-0 z-[9999] flex justify-center items-center">
-            <div className="w-462 h-280 backdrop-blur-md rounded-lg">
+            <div className="relative w-[924px] h-[560px] backdrop-blur-md rounded-lg">
                 {children}
             </div>
         </div>

--- a/src/views/reading-room/components/views/CreateReadingRoom.tsx
+++ b/src/views/reading-room/components/views/CreateReadingRoom.tsx
@@ -58,17 +58,20 @@ const CreateReadingRoom = ({ usage, onCloseModal }: CreateReadingRoomProps) => {
 
                     <div className='flex flex-row justify-center items-start gap-13 mt-10 px-10'>
                         <div className='flex flex-col'>
-                            <div className='flex flex-row items-center mb-20'>
-                                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none"
-                                    onClick={() => navigate('/reading-room')}>
-                                    <path fillRule="evenodd" clipRule="evenodd"
-                                        d="M14.1919 2.05806C14.436 2.30214 14.436 2.69786 14.1919 2.94194L7.13388 10L14.1919 17.0581C14.436 17.3021 14.436 17.6979 14.1919 17.9419C13.9479 18.186 13.5521 18.186 13.3081 17.9419L5.80806 10.4419C5.56398 10.1979 5.56398 9.80214 5.80806 9.55806L13.3081 2.05806C13.5521 1.81398 13.9479 1.81398 14.1919 2.05806Z"
-                                        fill="white" fillOpacity="0.5" />
-                                </svg>
+                            {usage === 'create' && (
+                                <div className='flex flex-row items-center mb-20'>
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none"
+                                        onClick={() => navigate('/reading-room')}>
+                                        <path fillRule="evenodd" clipRule="evenodd"
+                                            d="M14.1919 2.05806C14.436 2.30214 14.436 2.69786 14.1919 2.94194L7.13388 10L14.1919 17.0581C14.436 17.3021 14.436 17.6979 14.1919 17.9419C13.9479 18.186 13.5521 18.186 13.3081 17.9419L5.80806 10.4419C5.56398 10.1979 5.56398 9.80214 5.80806 9.55806L13.3081 2.05806C13.5521 1.81398 13.9479 1.81398 14.1919 2.05806Z"
+                                            fill="white" fillOpacity="0.5" />
+                                        </svg>
                             
-                                <div className='text-white text-xl ml-6'>내 리딩룸</div>
-                            </div>
-                            <img src={themeImages[selected]} alt={selected} className='w-270 h-221 rounded-xl' />
+                                    <div className='text-white text-xl ml-6'>내 리딩룸</div>
+                                </div>
+                            )}
+                            <img src={themeImages[selected]} alt={selected} 
+                            className={`${usage} === 'create' ? 'w-270 h-221 rounded-xl' : 'w-[446px] h-[365px] rounded-xl'}`} />
 
                             <div className='flex flex-col mt-6'>
                                 <div className='flex flex-row justify-start items-center gap-3'>
@@ -83,7 +86,7 @@ const CreateReadingRoom = ({ usage, onCloseModal }: CreateReadingRoomProps) => {
                                             src={themeImages[theme]}
                                             alt={theme}
                                             onClick={() => setSelected(theme)}
-                                            className={`cursor-pointer w-84 h-69 rounded-xl border transition-all duration-200 ${
+                                            className={`cursor-pointer ${usage === 'create' ? 'w-84 h-69' : 'w-[139.617px] h-[114.558px]'} rounded-xl border transition-all duration-200 ${
                                                 selected === theme
                                                     ? "border-[rgba(122,191,201,1)]"
                                                     : "border-transparent"
@@ -95,7 +98,7 @@ const CreateReadingRoom = ({ usage, onCloseModal }: CreateReadingRoomProps) => {
                             </div>
                         </div>
 
-                        <div className='flex flex-col justify-start mt-40'>
+                        <div className={`flex flex-col justify-start ${usage === 'create' ? 'mt-40' : 'mt-10'}`}>
                             <InsertInfo 
                                 roomName={roomName}
                                 setRoomName={setRoomName}

--- a/src/views/reading-room/components/views/CreateReadingRoom.tsx
+++ b/src/views/reading-room/components/views/CreateReadingRoom.tsx
@@ -1,13 +1,23 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Campfire from '../../../../assets/readingRoom/bg/Campfire.png';
 import Subway from '../../../../assets/readingRoom/bg/Subway.png';
 import ReadingRoom from '../../../../assets/readingRoom/bg/ReadingRoom.png';
 import InsertInfo from '../InsertInfo';
+import ActionButtons from '../ActionButtons';
+import { ReadingRoomActionsProvider } from '../../contexts/ReadingRoomActionsContext';
 
-const CreateReadingRoom = () => {
+
+type ThemeType = 'Campfire' | 'Subway' | 'ReadingRoom';
+type UsageType = 'create' | 'edit';
+
+interface CreateReadingRoomProps {
+    usage: UsageType; 
+    onCloseModal?: () => void;
+}
+
+const CreateReadingRoom = ({ usage, onCloseModal }: CreateReadingRoomProps) => {
     const navigate = useNavigate();
-    type ThemeType = 'Campfire' | 'Subway' | 'ReadingRoom';
     const[selected, setSelected] = useState<ThemeType>('Campfire');
 
     const [roomName, setRoomName] = useState('');
@@ -22,78 +32,84 @@ const CreateReadingRoom = () => {
         ReadingRoom,
     };
 
+    const actions = useMemo(() => {
+        return {
+            create: () => {
+                if (!isCreatingValid) return;
+                // TODO: 생성 로직 (API 요청 등)
+                console.log('리딩룸 생성!', { roomName, roomDescription, theme: selected });
+            },
+            edit: () => {
+                // TODO: 정보 수정 로직
+                console.log('정보 수정!', { roomName, roomDescription, theme: selected });
+            },
+            cancel: () => {
+                // TODO: 모달 닫기 or 페이지 이동
+                onCloseModal?.();
+                console.log('취소/닫기');
+            },
+        };
+    }, [isCreatingValid, roomName, roomDescription, selected, onCloseModal]);
+
     return(
-        <div className='flex flex-col justify-center items-center'>
-            <div className='relative w-full'>
+        <ReadingRoomActionsProvider value={actions}>
+            <div className='flex flex-col justify-center items-center'>
+                <div className='relative w-full'>
 
-                <div className='flex flex-row justify-center items-start gap-13 mt-10 px-10'>
-                    <div className='flex flex-col'>
-                        <div className='flex flex-row items-center mb-20'>
-                            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none"
-                                onClick={() => navigate('/reading-room')}>
-                                <path fillRule="evenodd" clipRule="evenodd"
-                                    d="M14.1919 2.05806C14.436 2.30214 14.436 2.69786 14.1919 2.94194L7.13388 10L14.1919 17.0581C14.436 17.3021 14.436 17.6979 14.1919 17.9419C13.9479 18.186 13.5521 18.186 13.3081 17.9419L5.80806 10.4419C5.56398 10.1979 5.56398 9.80214 5.80806 9.55806L13.3081 2.05806C13.5521 1.81398 13.9479 1.81398 14.1919 2.05806Z"
-                                    fill="white" fillOpacity="0.5" />
-                            </svg>
-                            
-                            <div className='text-white text-xl ml-6'>내 리딩룸</div>
-                        </div>
-                        <img src={themeImages[selected]} alt={selected} className='w-270 h-221 rounded-xl' />
-
-                        <div className='flex flex-col mt-6'>
-                            <div className='flex flex-row justify-start items-center gap-3'>
-                                <div className='text-white text-sm'>테마 선택</div>
-                                <div className='text-white text-2xs'>리딩룸 생성 후 테마를 변경할 수 있습니다.</div>
-                            </div>
-
-                            <div className='flex flex-row justify-start items-center gap-5 mt-7 mb-10'>
-                                {(['Campfire', 'Subway', 'ReadingRoom'] as ThemeType[]).map((theme) => (
-                                    <img
-                                        key={theme}
-                                        src={themeImages[theme]}
-                                        alt={theme}
-                                        onClick={() => setSelected(theme)}
-                                        className={`cursor-pointer w-84 h-69 rounded-xl border transition-all duration-200 ${
-                                            selected === theme
-                                                ? "border-[rgba(122,191,201,1)]"
-                                                : "border-transparent"
-                                        }`}
-                                        style={selected !== theme ? { filter: "blur(1px)", opacity: 0.5 } : undefined}
-                                    />
-                                ))}
-                            </div>
-                        </div>
-                    </div>
-
-                    <div className='flex flex-col justify-start mt-40'>
-                        <InsertInfo 
-                            roomName={roomName}
-                            setRoomName={setRoomName}
-                            roomDescription={roomDescription}
-                            setRoomDescription={setRoomDescription} />
-
-                        <div 
-                            className='flex flex-row justify-center items-center w-81 h-20 rounded-lg mt-110 ml-150 border'
-                            style={{ 
-                                backgroundColor: isCreatingValid ? 'rgba(122,191,201,1)' : 'transparent',
-                                borderColor : isCreatingValid? 'transparent' : 'rgba(66, 60, 53,1)',
-                                pointerEvents: isCreatingValid? 'auto' : 'none',
-                                color: isCreatingValid? 'black': 'rgba(66,60,53,1)'
-                                }}>
-                            <div 
-                                className='flex justify-center items-center rounded-full border mr-5 p-1'
-                                style={{ borderColor: 'rgba(43, 34, 23, 1)' }}>
-                                <svg xmlns="http://www.w3.org/2000/svg" width="9" height="9" viewBox="0 0 9 8" fill="none">
-                                    <path d="M4.44488 0.185547V4.00083M4.44488 7.8161V4.00083M4.44488 4.00083H0.722656M4.44488 4.00083H8.1671"
-                                    stroke="#2B2217" strokeWidth="0.372222" strokeLinecap="round" />
+                    <div className='flex flex-row justify-center items-start gap-13 mt-10 px-10'>
+                        <div className='flex flex-col'>
+                            <div className='flex flex-row items-center mb-20'>
+                                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none"
+                                    onClick={() => navigate('/reading-room')}>
+                                    <path fillRule="evenodd" clipRule="evenodd"
+                                        d="M14.1919 2.05806C14.436 2.30214 14.436 2.69786 14.1919 2.94194L7.13388 10L14.1919 17.0581C14.436 17.3021 14.436 17.6979 14.1919 17.9419C13.9479 18.186 13.5521 18.186 13.3081 17.9419L5.80806 10.4419C5.56398 10.1979 5.56398 9.80214 5.80806 9.55806L13.3081 2.05806C13.5521 1.81398 13.9479 1.81398 14.1919 2.05806Z"
+                                        fill="white" fillOpacity="0.5" />
                                 </svg>
+                            
+                                <div className='text-white text-xl ml-6'>내 리딩룸</div>
                             </div>
-                            <div className='text-sm'>리딩룸 생성하기</div>
+                            <img src={themeImages[selected]} alt={selected} className='w-270 h-221 rounded-xl' />
+
+                            <div className='flex flex-col mt-6'>
+                                <div className='flex flex-row justify-start items-center gap-3'>
+                                    <div className='text-white text-sm'>테마 선택</div>
+                                    <div className='text-white text-2xs'>리딩룸 생성 후 테마를 변경할 수 있습니다.</div>
+                                </div>
+
+                                <div className='flex flex-row justify-start items-center gap-5 mt-7 mb-10'>
+                                    {(['Campfire', 'Subway', 'ReadingRoom'] as ThemeType[]).map((theme) => (
+                                        <img
+                                            key={theme}
+                                            src={themeImages[theme]}
+                                            alt={theme}
+                                            onClick={() => setSelected(theme)}
+                                            className={`cursor-pointer w-84 h-69 rounded-xl border transition-all duration-200 ${
+                                                selected === theme
+                                                    ? "border-[rgba(122,191,201,1)]"
+                                                    : "border-transparent"
+                                            }`}
+                                        style={selected !== theme ? { filter: "blur(1px)", opacity: 0.5 } : undefined}
+                                        />
+                                    ))}
+                                </div>
+                            </div>
+                        </div>
+
+                        <div className='flex flex-col justify-start mt-40'>
+                            <InsertInfo 
+                                roomName={roomName}
+                                setRoomName={setRoomName}
+                                roomDescription={roomDescription}
+                                setRoomDescription={setRoomDescription} />
+
+                                <ActionButtons 
+                                    usage={usage} 
+                                    disabled={usage === 'create' && !isCreatingValid} />
                         </div>
                     </div>
                 </div>
             </div>
-        </div>
+        </ReadingRoomActionsProvider>
     );
 }
 

--- a/src/views/reading-room/contexts/ReadingRoomActionsContext.tsx
+++ b/src/views/reading-room/contexts/ReadingRoomActionsContext.tsx
@@ -1,0 +1,19 @@
+// readingRoomActionsContext.tsx
+import { createContext, useContext } from 'react';
+
+type Actions = {
+    create: () => void;
+    edit: () => void;
+    cancel: () => void;
+};
+
+const noop = () => {};
+const ReadingRoomActionsContext = createContext<Actions>({
+    create: noop,
+    edit: noop,
+    cancel: noop,
+});
+
+export const useReadingRoomActions = () => useContext(ReadingRoomActionsContext);
+
+export const ReadingRoomActionsProvider = ReadingRoomActionsContext.Provider;

--- a/src/views/reading-room/page/private-reading-room/index.tsx
+++ b/src/views/reading-room/page/private-reading-room/index.tsx
@@ -11,6 +11,8 @@ import DeleteBtn from '../../../../components/delete-modal/reading-room/DeleteMo
 import SmallControlBar from '../../components/private-reading-room/control-bar/SmallControlBar';
 import useSoundStore from '../../../../store/private-reading-room/useSoundStore';
 import SpeechBubble from '../../components/private-reading-room/speech-bubble/SpeechBubble';
+import CreateReadingRoom from '../../components/views/CreateReadingRoom';
+import Modal from '../../components/private-reading-room/common/ModifyModal';
 
 const PrivateReadingRoom = () => {
   const [memberClick, setMemberClick] = useState(false);
@@ -22,12 +24,18 @@ const PrivateReadingRoom = () => {
     toggleExitModal,
     isDeleteModalOpen,
     toggleDeleteModal,
+    isEditModalOpen,
+    openEditModal,
+    closeEditModal,
   } = useModalStore(
     useShallow((state) => ({
       isExitModalOpen: state.isExitModalOpen,
       toggleExitModal: state.toggleExitModal,
       isDeleteModalOpen: state.isDeleteModalOpen,
       toggleDeleteModal: state.toggleDeleteModal,
+      isEditModalOpen: state.isEditModalOpen,
+      openEditModal: state.openEditModal,
+      closeEditModal: state.closeEditModal,
     })),
   );
 
@@ -76,11 +84,16 @@ const PrivateReadingRoom = () => {
           <div className="absolute bottom-[130px] left-[394px]">
             <SmallControlBar
               onDelete={toggleDeleteModal}
-              // onEdit={}
+              onEdit={openEditModal}
               onSound={toggleSound}
             />
           </div>
         )}
+        {isEditModalOpen && (
+          <Modal onClose={closeEditModal}>
+            <CreateReadingRoom usage="edit" onCloseModal={closeEditModal} />
+          </Modal>
+        )}  
         <ControlBar
           roll="guest"
           onMemberClick={() => setMemberClick(!memberClick)}


### PR DESCRIPTION
## 🚀 관련 이슈

- close #82 

## 🔑 작업 내용

- CreateReadingRoom에서 usage를 사용하여 usage가 create 일때와 edit 일 때로 나눔
- private-readingRoom index page 에서 해당 modal 적용할 수 있도록 ModalStore에 상태 추가함
- Modal이 될 수 있도록 틀 컴포넌트 추가
- create일 땐 그대로 edit일 때는 모달 크기에 맞도록 사이즈가 변경이 되도록 CreateReadingRoom 수정

## 📷 스크린샷

- 모달일 경우(임시적을 내 리딩룸에서 띄워지도록 테스트 함)
<img width="1919" height="873" alt="image" src="https://github.com/user-attachments/assets/2f728e8f-026a-4e26-80e3-1ff1ebeff99e" />

- 페이지일 경우
- 
<img width="1919" height="865" alt="image" src="https://github.com/user-attachments/assets/68dfd821-3978-4989-9a51-64a5b50645ff" />



## 🌐 공유 사항 to 리뷰어
@woojo230 
- 제가 위에 테스트 방법 하기 전 private-ReadingRoom에서 테스트 해보고자, 주석 처리 해둔 onEdit 부분에 추가해뒀었습니다!
- api 연동하면서 문제 생기면 좀 더 손 보겠습니다!

## 🚨 이슈 사항

<!— 이슈가 발생하는 부분이 있다면 적어주세요 —>
