### PR TITLE
🐛 Fix: ReadingRoomCard 일러스트 위치 변경

### DIFF
--- a/src/views/reading-room/components/reading-room/ReadingRoomCard.tsx
+++ b/src/views/reading-room/components/reading-room/ReadingRoomCard.tsx
@@ -52,7 +52,7 @@ const ReadingRoomCard: React.FC<ReadingRoomCardProps> = ({ room, onClick }) => {
                 src={src}
                 alt="RoomCard"
                 className="absolute top-0 left-0 w-full h-full object-cover rounded-lg z-0"
-                style={{ objectPosition: '40% 50%' }} 
+                style={{ objectPosition: src === SUBWAY_IMG ? '10% 50%' : '40% 50%' }}
                 onError={(e) => { (e.currentTarget as HTMLImageElement).src = fallbackCard; }}
             />
     


### PR DESCRIPTION
## 🚀 관련 이슈

- close #209 

## 🔑 작업 내용

- ReadingRoomCard 일러스트 SUBWAY 위치 변

## 📷 스크린샷

<img width="1044" height="593" alt="image" src="https://github.com/user-attachments/assets/621aaf86-928a-404c-9ac9-509c01f37e18" />

## 🌐 공유 사항 to 리뷰어

<!— 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요 —>
<!— 논의해야 할 부분이 있다면 적어주세요 —>

## 🚨 이슈 사항

<!— 이슈가 발생하는 부분이 있다면 적어주세요 —>
