### PR TITLE
301 feature 책정보 api 연결

### DIFF
--- a/src/api/bookInfo.ts
+++ b/src/api/bookInfo.ts
@@ -1,0 +1,24 @@
+import { api } from "./axios";
+
+import type { BaseApiResponse } from "../types/index.type";
+import type { BookDetailResponse } from "../types/bookInfo/bookDetail.type";
+
+const RECORDS_ENDPOINT = "/api/v1/books";
+
+export async function getBookDetailWithISBN(
+  isbn: string,
+): Promise<BookDetailResponse> {
+  const response = await api.get<BaseApiResponse<BookDetailResponse>>(
+    `${RECORDS_ENDPOINT}/${isbn}`,
+  );
+  return response.data.result;
+}
+
+export async function getBookDetailWithBookId(
+  bookId: number,
+): Promise<BookDetailResponse> {
+  const response = await api.get<BaseApiResponse<BookDetailResponse>>(
+    `${RECORDS_ENDPOINT}/${bookId}`,
+  );
+  return response.data.result;
+}

--- a/src/api/library.ts
+++ b/src/api/library.ts
@@ -2,17 +2,17 @@ import { api } from "./axios";
 import type BaseApiResponse from "../types/BaseApiResponse";
 
 import type {
-   LibraryBook,
-   LibraryBookGoal,
-   LibraryDateFocus,
-   BookStatusType,
-   LibraryStatusBook,
-   PatchBookGoal,
-   LibraryFocusMonthly,
-   LibraryBooksMonthly,
-   DateToggleYear,
-   RecentBookInfo,
-   SpecificDateBookInfo,
+  LibraryBook,
+  LibraryBookGoal,
+  LibraryDateFocus,
+  BookStatusType,
+  LibraryStatusBook,
+  PatchBookGoal,
+  LibraryFocusMonthly,
+  LibraryBooksMonthly,
+  DateToggleYear,
+  RecentBookInfo,
+  SpecificDateBookInfo,
 } from "../types/libraryInfo/library";
 
 const LIBRARY_BASE = "/api/v1/library";
@@ -127,11 +127,32 @@ export function getRecentBookInfo() {
 }
 
 export function getLibrarySpecificBookInfo(params: {
-  date: string,
-  cursor: number,
-}) :Promise<SpecificDateBookInfo> {
+  date: string;
+  cursor: number;
+}): Promise<SpecificDateBookInfo> {
   return libraryGet<SpecificDateBookInfo>("focus-records", {
     date: params.date,
-    cursro: params.cursor,
-  })
+    cursor: params.cursor,
+  });
+}
+
+// 서재 책 등록
+export async function postLibraryBook(bookId: string): Promise<void> {
+  await api.post(`"/api/library/${bookId}"`);
+}
+
+// 서재 책 삭제
+export async function deleteLibraryBook(bookId: string): Promise<void> {
+  await api.delete(`/api/library/${bookId}`);
+}
+
+// 서재 책 상태 변경 => 수정 필요
+export async function patchLibraryBookStatus(params: {
+  bookId: string;
+  readingStatus: BookStatusType;
+}): Promise<void> {
+  await api.patch(`/api/library/status`, {
+    bookId: params.bookId,
+    readingStatus: params.readingStatus,
+  });
 }

--- a/src/app/AppRoutes.tsx
+++ b/src/app/AppRoutes.tsx
@@ -159,9 +159,15 @@ export default function AppRoutes() {
               <Route path="profile" element={<OnboardingProfilePage />} />
             </Route>
 
-            <Route path="/users/me/onboarding/goal" element={<LibraryGoalInputPage />} />
-            <Route path="/library/123" element={<BookInfoPage />} />
-            <Route path="/library/123/history" element={<AllHistoryPage />} />
+            <Route
+              path="/users/me/onboarding/goal"
+              element={<LibraryGoalInputPage />}
+            />
+            <Route path="/library/:isbn13" element={<BookInfoPage />} />
+            <Route
+              path="/library/:isbn13/history"
+              element={<AllHistoryPage />}
+            />
           </Route>
 
           <Route path="/report/search" element={<ReportSearchPage />} />

--- a/src/components/action/Chip/Emotion.tsx
+++ b/src/components/action/Chip/Emotion.tsx
@@ -105,7 +105,12 @@ export default function Emotion({
   if (size === "s") {
     return (
       <span
-        className={[base, sizeClassMap.s, background, active ? color : inactive].join(" ")}
+        className={[
+          base,
+          sizeClassMap.s,
+          background,
+          active ? color : inactive,
+        ].join(" ")}
       >
         <span className={emoji}>{emojiFeature}</span>
       </span>
@@ -113,9 +118,10 @@ export default function Emotion({
   }
 
   return (
-
-    <span className={[base, sizeClassMap.m, background].join(" ")}>
-
+    <span
+      className={[base, sizeClassMap.m, background].join(" ")}
+      onClick={onClick}
+    >
       <span className={`${emoji} ${active ? color : inactive}`}>
         {emojiFeature}
       </span>

--- a/src/components/search/AllBookListSection.tsx
+++ b/src/components/search/AllBookListSection.tsx
@@ -1,4 +1,5 @@
 import { useRef } from "react";
+import { useNavigate } from "react-router-dom";
 
 import bookCover from "../../assets/search/mock_bookcover.svg";
 import type { GlobalHomeBookItem } from "../../api/search";
@@ -11,6 +12,8 @@ type Props = {
 const LIMIT = 5;
 
 function HorizontalBookScroller({ books }: { books: GlobalHomeBookItem[] }) {
+  const navigate = useNavigate();
+
   const ref = useRef<HTMLDivElement | null>(null);
   const isDragging = useRef(false);
   const startX = useRef(0);
@@ -79,6 +82,10 @@ function HorizontalBookScroller({ books }: { books: GlobalHomeBookItem[] }) {
           <div
             key={`${book.isbn13}-${index}`}
             className="shrink-0 w-25 snap-start flex flex-col items-start"
+            onClick={() => {
+              console.log("navigate to book detail", book.isbn13);
+              navigate(`/library/${book.isbn13}`);
+            }}
           >
             <img
               src={book.coverImageUrl || bookCover}
@@ -110,6 +117,8 @@ export default function AllBookListSection({
   recommendedBooks,
   bestBooks,
 }: Props) {
+  const navigate = useNavigate();
+
   return (
     <section className="w-full flex flex-col items-start gap-8 pt-8">
       <div className="w-full flex flex-col items-start gap-4">
@@ -125,9 +134,15 @@ export default function AllBookListSection({
             <div
               key={`best-${book.isbn13}-${idx}`}
               className="w-full h-7 flex items-center gap-2"
+              onClick={() => {
+                console.log("navigate to book detail", book.isbn13);
+                navigate(`/library/${book.isbn13}`);
+              }}
             >
               <div className="w-7 h-7 flex items-center justify-center">
-                <span className="text-gray-90 text-btn-16-sb">{book.rank ?? idx + 1}</span>
+                <span className="text-gray-90 text-btn-16-sb">
+                  {book.rank ?? idx + 1}
+                </span>
               </div>
 
               <div className="flex-1 overflow-hidden py-1">

--- a/src/components/search/AllBookListSection.tsx
+++ b/src/components/search/AllBookListSection.tsx
@@ -16,6 +16,7 @@ function HorizontalBookScroller({ books }: { books: GlobalHomeBookItem[] }) {
 
   const ref = useRef<HTMLDivElement | null>(null);
   const isDragging = useRef(false);
+  const dragMoved = useRef(false);
   const startX = useRef(0);
   const startScrollLeft = useRef(0);
 
@@ -24,15 +25,16 @@ function HorizontalBookScroller({ books }: { books: GlobalHomeBookItem[] }) {
     const el = ref.current;
     if (!el) return;
 
-    e.preventDefault();
+    // e.preventDefault();
     isDragging.current = true;
+    dragMoved.current = false;
     startX.current = e.clientX;
     startScrollLeft.current = el.scrollLeft;
 
     el.style.scrollSnapType = "none";
     el.style.scrollBehavior = "auto";
-    el.style.cursor = "grabbing";
-    el.setPointerCapture(e.pointerId);
+    // el.style.cursor = "grabbing";
+    // el.setPointerCapture(e.pointerId);
   };
 
   const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
@@ -40,24 +42,31 @@ function HorizontalBookScroller({ books }: { books: GlobalHomeBookItem[] }) {
     const el = ref.current;
     if (!el) return;
 
+    // 마우스 이동 거리가 5px 이상일 때만 '드래그'로 판정
+    if (Math.abs(e.clientX - startX.current) > 5) {
+      dragMoved.current = true;
+    }
+
     e.preventDefault();
     el.scrollLeft = startScrollLeft.current - (e.clientX - startX.current);
   };
 
-  const endDrag = (e: React.PointerEvent<HTMLDivElement>) => {
-    if (!isDragging.current) return;
-    isDragging.current = false;
+  const endDrag = () =>
+    //e: React.PointerEvent<HTMLDivElement>
+    {
+      if (!isDragging.current) return;
+      isDragging.current = false;
 
-    const el = ref.current;
-    if (!el) return;
+      const el = ref.current;
+      if (!el) return;
 
-    el.style.scrollSnapType = "x mandatory";
-    el.style.scrollBehavior = "smooth";
-    el.style.cursor = "grab";
-    try {
-      el.releasePointerCapture(e.pointerId);
-    } catch {}
-  };
+      el.style.scrollSnapType = "x mandatory";
+      el.style.scrollBehavior = "smooth";
+      // el.style.cursor = "grab";
+      // try {
+      //   el.releasePointerCapture(e.pointerId);
+      // } catch {}
+    };
 
   return (
     <div
@@ -67,7 +76,7 @@ function HorizontalBookScroller({ books }: { books: GlobalHomeBookItem[] }) {
       onPointerUp={endDrag}
       onPointerCancel={endDrag}
       onPointerLeave={endDrag}
-      style={{ touchAction: "pan-x" }}
+      style={{ touchAction: "pan-y" }}
       className={[
         "w-[calc(100%+16px)] -mr-4",
         "overflow-x-auto",
@@ -81,8 +90,13 @@ function HorizontalBookScroller({ books }: { books: GlobalHomeBookItem[] }) {
         {books.slice(0, LIMIT).map((book, index) => (
           <div
             key={`${book.isbn13}-${index}`}
-            className="shrink-0 w-25 snap-start flex flex-col items-start"
-            onClick={() => {
+            className="shrink-0 w-25 snap-start flex flex-col items-start cursor-pointer"
+            onClick={(e) => {
+              if (dragMoved.current) {
+                e.preventDefault();
+                e.stopPropagation();
+                return;
+              }
               console.log("navigate to book detail", book.isbn13);
               navigate(`/library/${book.isbn13}`);
             }}

--- a/src/components/search/SearchResultSection.tsx
+++ b/src/components/search/SearchResultSection.tsx
@@ -1,4 +1,5 @@
 // Client/src/components/search/SearchResultSection.tsx
+import { useNavigate } from "react-router-dom";
 import bookCover from "../../assets/search/mock_bookcover.svg";
 import physicalBookIcon from "../../assets/search/card-book-icon-shape.svg";
 import type { SearchScope } from "./SearchTopSection";
@@ -25,8 +26,16 @@ function ResultRow({
   book: SearchBookItem;
   showDivider: boolean;
 }) {
+  const navigate = useNavigate();
+
   return (
-    <div className="flex flex-col items-center self-stretch">
+    <div
+      className="flex flex-col items-center self-stretch"
+      onClick={() => {
+        console.log("navigate to book detail", book.isbn13);
+        navigate(`/library/${book.isbn13}`);
+      }}
+    >
       <div className="w-full flex items-start gap-3 py-3 relative">
         <div className="flex justify-center items-center shrink-0 w-14 h-20.5">
           <img
@@ -125,7 +134,6 @@ export default function SearchResultSection({
   const filtered = q ? safeBooks : [];
   const isEmpty = !isLoading && filtered.length === 0;
 
-
   return (
     <section className="w-full flex flex-col items-start gap-10">
       <div className="w-full flex flex-col items-start pt-5">
@@ -177,4 +185,3 @@ export default function SearchResultSection({
     </section>
   );
 }
-

--- a/src/hooks/mutations/library/useLibraryBookRegister.ts
+++ b/src/hooks/mutations/library/useLibraryBookRegister.ts
@@ -1,0 +1,39 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  postLibraryBook,
+  deleteLibraryBook,
+  patchLibraryBookStatus,
+} from "../../../api/library";
+import type { BookStatusType } from "../../../types/libraryInfo/library";
+
+export function useLibraryBookRegister() {
+  const queryClient = useQueryClient();
+
+  const addBookMutation = useMutation({
+    mutationFn: (bookId: string) => postLibraryBook(bookId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["libraryBooks"] });
+    },
+  });
+
+  const deleteBookMutation = useMutation({
+    mutationFn: (bookId: string) => deleteLibraryBook(bookId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["libraryBooks"] });
+    },
+  });
+
+  const patchBookStatusMutation = useMutation({
+    mutationFn: (params: { bookId: string; readingStatus: BookStatusType }) =>
+      patchLibraryBookStatus(params),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["libraryBooks"] });
+    },
+  });
+
+  return {
+    addBook: addBookMutation.mutate,
+    deleteBook: deleteBookMutation.mutate,
+    patchBookStatus: patchBookStatusMutation.mutate,
+  };
+}

--- a/src/hooks/queries/bookInfo/useGetBookDetailWithBookId.ts
+++ b/src/hooks/queries/bookInfo/useGetBookDetailWithBookId.ts
@@ -1,0 +1,9 @@
+import { getBookDetailWithBookId } from "../../../api/bookInfo";
+import { useQuery } from "@tanstack/react-query";
+
+export function useGetBookDetailWithBookId(bookId: number) {
+  return useQuery({
+    queryKey: ["bookDetail", bookId],
+    queryFn: () => getBookDetailWithBookId(bookId),
+  });
+}

--- a/src/hooks/queries/bookInfo/useGetBookDetailWithISBN.ts
+++ b/src/hooks/queries/bookInfo/useGetBookDetailWithISBN.ts
@@ -1,0 +1,9 @@
+import { getBookDetailWithISBN } from "../../../api/bookInfo";
+import { useQuery } from "@tanstack/react-query";
+
+export function useGetBookDetailWithISBN(isbn: string) {
+  return useQuery({
+    queryKey: ["bookDetail", isbn],
+    queryFn: () => getBookDetailWithISBN(isbn),
+  });
+}

--- a/src/pages/bookInfo/BookInfoPage.tsx
+++ b/src/pages/bookInfo/BookInfoPage.tsx
@@ -1,5 +1,5 @@
 // libraries
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 // components
@@ -113,6 +113,15 @@ export default function BookInfoPage() {
   const { data: bookDetailData, isLoading } = useGetBookDetailWithISBN(
     bookISBN!,
   );
+
+  // 데이터가 null일 때 alert 띄우기 (렌더링 사이드 이펙트 방지)
+  useEffect(() => {
+    // 로딩이 끝났고, 데이터가 명시적으로 null인 경우
+    if (!isLoading && bookDetailData === null) {
+      alert("잠시후에 다시 시도해주세요");
+      navigate(-1); // 이전 페이지로 이동
+    }
+  }, [isLoading, bookDetailData]);
 
   // 개발용 상태
   const [hasFocus, setHasFocus] = useState(true);

--- a/src/pages/bookInfo/BookInfoPage.tsx
+++ b/src/pages/bookInfo/BookInfoPage.tsx
@@ -19,7 +19,7 @@ import testBookCover from "../../assets/book-info/testBookCover.svg";
 import book_shelf from "../../assets/icons/book_shelf-gray-30.svg";
 // hooks
 import { useGetBookDetailWithISBN } from "../../hooks/queries/bookInfo/useGetBookDetailWithISBN";
-import { useLibraryBookRegister } from "../../hooks/mutations/library/useLibraryBookRegister";
+// import { useLibraryBookRegister } from "../../hooks/mutations/library/useLibraryBookRegister";
 // types
 type DetailTab = "info" | "log";
 // values

--- a/src/pages/bookInfo/BookInfoPage.tsx
+++ b/src/pages/bookInfo/BookInfoPage.tsx
@@ -1,6 +1,7 @@
 // libraries
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
+
 // components
 import TopNavigation from "../../components/navigation/topnavigation/TopNavigation";
 import BookCover from "../../components/atomic/BookCover";
@@ -17,6 +18,8 @@ import ResourceDate from "../../components/content/list/Resource/Date";
 import chevron_left from "../../assets/icons/chevron_left.svg";
 import testBookCover from "../../assets/book-info/testBookCover.svg";
 import book_shelf from "../../assets/icons/book_shelf-gray-30.svg";
+// hooks
+import { useGetBookDetailWithISBN } from "../../hooks/queries/bookInfo/useGetBookDetailWithISBN";
 // types
 type DetailTab = "info" | "log";
 // values
@@ -25,31 +28,6 @@ const detailTabs = [
   { value: "log", label: "독서 이력" },
 ] as const;
 // data
-const bookData = {
-  isSuccess: true,
-  code: "SUCCESS-200",
-  message: "요청에 성공했습니다.",
-  result: {
-    book: {
-      isbn13: "9791162243077",
-      bookId: 101,
-      title: "이것이 자바다",
-      author: "신용권, 임경균",
-      publisher: "한빛미디어",
-      publicationDate: "2022-09-05",
-      mallType: "국내도서",
-      mallTypeCode: "BOOK",
-      category: "IT",
-      pages: 900,
-      description:
-        "자바의 정석 기초편 출간 20주년 기념판. 자바의 정석은 자바 입문서의 스테디셀러로, 2002년 출간 이후 20년 동안 꾸준히 사랑받아온 책입니다. 이번에 출간된 기념판은 자바의 최신 버전인 자바 17을 기반으로 내용을 대폭 보강하였으며, 기존의 친절한 설명과 자세한 예제는 그대로 유지하면서도 최신 트렌드와 기술을 반영하여 독자들이 자바를 더욱 쉽고 재미있게 배울 수 있도록 구성하였습니다.",
-      coverImageUrl: "https://image.aladin.co.kr/...",
-      aladinLink: "http://...",
-      sourceType: "ALADIN",
-      bookshelfId: 52,
-    },
-  },
-};
 const bookHistoryData = [
   {
     year: 2026,
@@ -120,6 +98,7 @@ const bookHistoryData = [
 ];
 
 export default function BookInfoPage() {
+  const bookISBN = useParams().isbn13;
   const navigate = useNavigate();
 
   const [selectedTab, setSelectedTab] = useState<DetailTab>("info");
@@ -130,6 +109,11 @@ export default function BookInfoPage() {
     open: false,
     message: "",
   });
+
+  const { data: bookDetailData, isLoading } = useGetBookDetailWithISBN(
+    bookISBN!,
+  );
+
   // 개발용 상태
   const [hasFocus, setHasFocus] = useState(true);
   const [hasRecord, setHasRecord] = useState(false);
@@ -171,12 +155,17 @@ export default function BookInfoPage() {
       <div className="relative">
         <div className="absolute inset-0 z-0 -mx-4 -mt-2 pointer-events-none overflow-hidden">
           <div className="absolute bottom-0 left-1/2 -translate-x-1/2 w-[375px] h-[525px]">
-            <BookCover
-              imageUrl={testBookCover}
-              size="XL"
-              type="Image"
-              className="w-full h-full blur-[20px] opacity-50"
-            />
+            {/* 배경 흐림 커버 스켈레톤 */}
+            {isLoading ? (
+              <div className="w-full h-full bg-gray-20 animate-pulse blur-[20px] opacity-50" />
+            ) : (
+              <BookCover
+                imageUrl={bookDetailData?.coverImageUrl || testBookCover}
+                size="XL"
+                type="Image"
+                className="w-full h-full blur-[20px] opacity-50"
+              />
+            )}
             <div className="absolute inset-0 bg-black opacity-40" />
             <div className="absolute inset-0 bg-linear-to-b from-transparent to-gray-10" />
           </div>
@@ -184,17 +173,37 @@ export default function BookInfoPage() {
         <div className="relative z-10">
           <TopNavigation
             left={<img src={chevron_left} alt="back" />}
-            onClickLeft={() => window.history.back()}
+            onClickLeft={() => navigate(-1)}
           />
           <div className="flex flex-col justify-center items-center mt-10 gap-4">
-            <BookCover imageUrl={testBookCover} size="XL" type="Image" />
-            <div>
-              <p className="text-title-18-b text-gray-90 text-center">
-                {bookData.result.book.title}
-              </p>
-              <p className="text-body-14-m text-gray-80 mt-[6px] text-center">
-                {bookData.result.book.author}
-              </p>
+            {/* 메인 도서 커버 스켈레톤 */}
+            {isLoading ? (
+              <div className="w-[140px] h-[200px] bg-gray-20 animate-pulse rounded-md" />
+            ) : (
+              <BookCover
+                imageUrl={bookDetailData?.coverImageUrl || testBookCover}
+                size="XL"
+                type="Image"
+              />
+            )}
+
+            <div className="flex flex-col items-center gap-2">
+              {/* 타이틀 & 저자 스켈레톤 */}
+              {isLoading ? (
+                <>
+                  <div className="w-48 h-6 bg-gray-20 animate-pulse rounded-sm" />
+                  <div className="w-24 h-4 bg-gray-20 animate-pulse rounded-sm mt-1" />
+                </>
+              ) : (
+                <>
+                  <p className="text-title-18-b text-gray-90 text-center">
+                    {bookDetailData?.title}
+                  </p>
+                  <p className="text-body-14-m text-gray-80 text-center">
+                    {bookDetailData?.author}
+                  </p>
+                </>
+              )}
             </div>
           </div>
           <TabBar
@@ -209,35 +218,47 @@ export default function BookInfoPage() {
       {/* 하단 */}
       {selectedTab === "info" ? (
         <div className="flex flex-col justify-center items-center gap-10 mt-8">
-          <div className="grid grid-cols-2 gap-8 text-gray-90">
-            <div className="col-span-2 w-full">
-              <InformationSection
-                flow="vertical"
-                top="소개"
-                bottom={bookData.result.book.description}
-              />
-            </div>
-
-            <InformationSection
-              flow="vertical"
-              top="분야"
-              bottom={bookData.result.book.category}
-            />
-            <InformationSection
-              flow="vertical"
-              top="분량"
-              bottom={`${bookData.result.book.pages}쪽`}
-            />
-            <InformationSection
-              flow="vertical"
-              top="출판"
-              bottom={`${bookData.result.book.publisher} (${bookData.result.book.publicationDate})`}
-            />
-            <InformationSection
-              flow="vertical"
-              top="ISBN"
-              bottom={bookData.result.book.isbn13}
-            />
+          <div className="grid grid-cols-2 gap-8 text-gray-90 w-full px-4">
+            {/* 정보 섹션 스켈레톤 */}
+            {isLoading ? (
+              <>
+                <div className="col-span-2 w-full h-24 bg-gray-15 animate-pulse rounded-sm" />
+                <div className="w-full h-12 bg-gray-15 animate-pulse rounded-sm" />
+                <div className="w-full h-12 bg-gray-15 animate-pulse rounded-sm" />
+                <div className="w-full h-12 bg-gray-15 animate-pulse rounded-sm" />
+                <div className="w-full h-12 bg-gray-15 animate-pulse rounded-sm" />
+              </>
+            ) : (
+              <>
+                <div className="col-span-2 w-full">
+                  <InformationSection
+                    flow="vertical"
+                    top="소개"
+                    bottom={bookDetailData?.description}
+                  />
+                </div>
+                <InformationSection
+                  flow="vertical"
+                  top="분야"
+                  bottom={bookDetailData?.category}
+                />
+                <InformationSection
+                  flow="vertical"
+                  top="분량"
+                  bottom={`${bookDetailData?.pages}쪽`}
+                />
+                <InformationSection
+                  flow="vertical"
+                  top="출판"
+                  bottom={`${bookDetailData?.publisher} (${bookDetailData?.publicationDate})`}
+                />
+                <InformationSection
+                  flow="vertical"
+                  top="ISBN"
+                  bottom={bookDetailData?.isbn13}
+                />
+              </>
+            )}
           </div>
           <div className="flex flex-col gap-2 w-full justify-center items-center">
             {readStatus !== "unread" && (
@@ -248,17 +269,19 @@ export default function BookInfoPage() {
                 onClick={() => setReadStatus("unread")}
               />
             )}
-            <div className="flex gap-2 text-gray-50 text-label-12-sb">
-              <div>도서 DB 제공: 알라딘</div>
-              <div
-                className="underline cursor-pointer"
-                onClick={() =>
-                  window.open(bookData.result.book.aladinLink, "_blank")
-                }
-              >
-                도서 구매하기
+            {!isLoading && bookDetailData?.aladinLink && (
+              <div className="flex gap-2 text-gray-50 text-label-12-sb">
+                <div>도서 DB 제공: 알라딘</div>
+                <div
+                  className="underline cursor-pointer"
+                  onClick={() =>
+                    window.open(bookDetailData?.aladinLink!, "_blank")
+                  }
+                >
+                  도서 구매하기
+                </div>
               </div>
-            </div>
+            )}
           </div>
         </div>
       ) : (

--- a/src/pages/bookInfo/BookInfoPage.tsx
+++ b/src/pages/bookInfo/BookInfoPage.tsx
@@ -1,7 +1,6 @@
 // libraries
 import { useState, useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-
 // components
 import TopNavigation from "../../components/navigation/topnavigation/TopNavigation";
 import BookCover from "../../components/atomic/BookCover";
@@ -20,6 +19,7 @@ import testBookCover from "../../assets/book-info/testBookCover.svg";
 import book_shelf from "../../assets/icons/book_shelf-gray-30.svg";
 // hooks
 import { useGetBookDetailWithISBN } from "../../hooks/queries/bookInfo/useGetBookDetailWithISBN";
+import { useLibraryBookRegister } from "../../hooks/mutations/library/useLibraryBookRegister";
 // types
 type DetailTab = "info" | "log";
 // values

--- a/src/types/bookInfo/bookDetail.type.ts
+++ b/src/types/bookInfo/bookDetail.type.ts
@@ -1,0 +1,17 @@
+export interface BookDetailResponse {
+  isbn13: string;
+  bookId: number;
+  title: string;
+  author: string;
+  publisher: string;
+  publicationDate: string;
+  mallType: string;
+  mallTypeCode: string;
+  category: string;
+  pages: number;
+  description: string;
+  coverImageUrl: string;
+  aladinLink: string | null;
+  sourceType: string;
+  bookShelfId: number | null;
+}


### PR DESCRIPTION
<!--
    PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) ✨ feat: 로그인 페이지 UI 구현
    PR 날릴 때 Assignees는 자기 자신 선택
    PR 날릴 때 Reviewers는 다른 팀원 선택해주기(최소 두명 이상)
-->

## 🚀 관련 이슈
- 추후 서재 등록, 삭제, 변경 api와 history api 연결이 필요해서 이슈는 안닫겠습니다!

## 🔑 작업 내용

<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- 검색페이지에서 책 클릭 시 도서 상세보기로 이동
- 도서 상세보기 api 연결 
- 도서 상세보기 skeleton UI 제작
- 도서 상세보기 data null 일시, 이전페이지로 강제로 이동, 오류 alert
- 검색페이지 추천페이지 드래그가 우선되어 클릭이 안되는 문제 해결
  
## 📷 스크린샷


https://github.com/user-attachments/assets/4fecf7dd-c9a7-44c3-aa71-fa1e960714e1




## 🌐 공유 사항 to 리뷰어


## 🚨 이슈 사항

검색 베스트셀러, 추천도서 api 속도가 느린 것 같아서 스켈레톤ui 추가하면 좋을 것 같습니다
